### PR TITLE
h2load rate and num connections options 

### DIFF
--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -74,8 +74,8 @@ namespace h2load {
 Config::Config()
     : data_length(-1), addrs(nullptr), nreqs(1), nclients(1), nthreads(1),
       max_concurrent_streams(-1), window_bits(30), connection_window_bits(30),
-      no_tls_proto(PROTO_HTTP2), data_fd(-1), port(0), default_port(0),
-      verbose(false), nconns(0), rate(0), current_worker(0) {}
+      rate(0), nconns(0), no_tls_proto(PROTO_HTTP2), data_fd(-1), port(0), default_port(0),
+      verbose(false), current_worker(0) {}
 
 Config::~Config() {
   freeaddrinfo(addrs);

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -1083,7 +1083,7 @@ Options:
               completed or failed. When the number of connections is
               0, the program will run as it normally does, creating as
               many connections as it needs in order to make the '-n'
-              requests specified. The defauly value for this option is
+              requests specified. The default value for this option is
               0. The '-n' option is not required if the '-C' option
               is being used.
   -v, --verbose

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -75,7 +75,8 @@ Config::Config()
     : data_length(-1), addrs(nullptr), nreqs(1), nclients(1), nthreads(1),
       max_concurrent_streams(-1), window_bits(30), connection_window_bits(30),
       no_tls_proto(PROTO_HTTP2), data_fd(-1), port(0), default_port(0),
-      verbose(false) {}
+      verbose(false), 
+      nconns(0), rate(0), current_worker(0) {}
 
 Config::~Config() {
   freeaddrinfo(addrs);
@@ -83,6 +84,10 @@ Config::~Config() {
   if (data_fd != -1) {
     close(data_fd);
   }
+}
+
+bool Config::is_rate_mode() {    
+  return (this->rate != 0);    
 }
 
 Config config;
@@ -261,7 +266,7 @@ void Client::process_abandoned_streams() {
 }
 
 void Client::report_progress() {
-  if (worker->id == 0 &&
+  if (!worker->config->is_rate_mode() && worker->id == 0 &&
       worker->stats.req_done % worker->progress_interval == 0) {
     std::cout << "progress: "
               << worker->stats.req_done * 100 / worker->stats.req_todo
@@ -963,6 +968,33 @@ std::vector<std::string> read_uri_from_file(std::istream &infile) {
 } // namespace
 
 namespace {
+// Called every second when rate mode is being used
+void second_timeout_cb(EV_P_ ev_timer *w, int revents) {
+  auto config = static_cast<Config *>(w->data);
+
+  auto nclients_per_worker = config->rate;
+  auto nreqs_per_worker = config->max_concurrent_streams * config->rate;
+
+  if(config->current_worker >= std::max(0. , (config->seconds - 1.))) {
+    nclients_per_worker = config->rate + config->conns_remainder;
+    nreqs_per_worker = (int)config->max_concurrent_streams *
+                       (config->rate + config->conns_remainder);
+    ev_timer_stop(config->rate_loop, w);
+  }
+
+  config->workers.push_back(make_unique<Worker>(config->current_worker,
+                                                config->ssl_ctx,
+                                                nreqs_per_worker,
+                                                nclients_per_worker,
+                                                config));
+
+  config->current_worker++;
+
+  config->workers.back()->run();
+}
+} // namespace
+
+namespace {
 void print_version(std::ostream &out) {
   out << "h2load nghttp2/" NGHTTP2_VERSION << std::endl;
 }
@@ -1027,6 +1059,7 @@ Options:
   -p, --no-tls-proto=<PROTOID>
               Specify ALPN identifier of the  protocol to be used when
               accessing http URI without SSL/TLS.)";
+
 #ifdef HAVE_SPDYLAY
   out << R"(
               Available protocols: spdy/2, spdy/3, spdy/3.1 and )";
@@ -1039,6 +1072,24 @@ Options:
   -d, --data=<FILE>
               Post FILE to  server.  The request method  is changed to
               POST.
+  -r, --rate=<N>
+              Specified the fixed rate at which connections are
+              created. The rate must be a positive integer,
+              representing the number of connections to be made per
+              second. When the rate is 0, the program will run as it
+              normally does, creating connections at whatever variable
+              rate it wants. The default value for this option is 0.
+  -C, --num-conns=<N>
+              Specifies the total number of connections to create. The
+              total number of connections must be a positive integer.
+              On each connection, '-m' requests are made. The test
+              stops once as soon as the N connections have either
+              completed or failed. When the number of connections is
+              0, the program will run as it normally does, creating as
+              many connections as it needs in order to make the '-n'
+              requests specified. The defauly value for this option is
+              0. The '-n' option is not required if the '-C' option
+              is being used.
   -v, --verbose
               Output debug information.
   --version   Display version information and exit.
@@ -1073,10 +1124,12 @@ int main(int argc, char **argv) {
         {"help", no_argument, nullptr, 'h'},
         {"version", no_argument, &flag, 1},
         {"ciphers", required_argument, &flag, 2},
+        {"rate", required_argument, nullptr, 'r'},
+        {"num-conns", required_argument, nullptr, 'C'},
         {nullptr, 0, nullptr, 0}};
     int option_index = 0;
-    auto c = getopt_long(argc, argv, "hvW:c:d:m:n:p:t:w:H:i:", long_options,
-                         &option_index);
+    auto c = getopt_long(argc, argv, "hvW:c:d:m:n:p:t:w:H:i:r:C:", 
+                         long_options, &option_index);
     if (c == -1) {
       break;
     }
@@ -1170,6 +1223,24 @@ int main(int argc, char **argv) {
         exit(EXIT_FAILURE);
       }
       break;
+    case 'r':
+      config.rate = strtoul(optarg, nullptr, 10);
+      if (config.rate <= 0) {
+        std::cerr << "-r: the rate at which connections are made "
+                  << "must be positive."
+                  << std::endl;
+        exit(EXIT_FAILURE);
+      }
+      break;
+    case 'C':
+      config.nconns = strtoul(optarg, nullptr, 10);
+      if (config.nconns <= 0) {
+        std::cerr << "-C: the total number of connections made "
+                  << "must be positive."
+                  << std::endl;
+        exit(EXIT_FAILURE);
+      }
+      break;
     case 'v':
       config.verbose = true;
       break;
@@ -1236,6 +1307,25 @@ int main(int argc, char **argv) {
   if (config.nthreads > std::thread::hardware_concurrency()) {
     std::cerr << "-t: warning: the number of threads is greater than hardware "
               << "cores." << std::endl;
+  }
+
+  if (config.nconns < 0) {
+    std::cerr << "-C: the total number of connections made "
+              << "cannot be negative."
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  if (config.rate < 0) {
+    std::cerr << "-r: the rate at which connections are made "
+              << "cannot be negative."
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  if (config.rate != 0 && config.nthreads != 1) {
+    std::cerr << "-r, -t: warning: the -t option will be ignored when the -r "
+              << "option is in use." << std::endl;
   }
 
   if (!datafile.empty()) {
@@ -1405,46 +1495,92 @@ int main(int argc, char **argv) {
 
   auto start = std::chrono::steady_clock::now();
 
-  std::vector<std::unique_ptr<Worker>> workers;
-  workers.reserve(config.nthreads);
-
+  // if not in rate mode, continue making workers and clients normally
+  if (!config.is_rate_mode()) {
+    config.workers.reserve(config.nthreads);
 #ifndef NOTHREADS
-  std::vector<std::future<void>> futures;
-  for (size_t i = 0; i < config.nthreads - 1; ++i) {
-    auto nreqs = nreqs_per_thread + (nreqs_rem-- > 0);
-    auto nclients = nclients_per_thread + (nclients_rem-- > 0);
-    std::cout << "spawning thread #" << i << ": " << nclients
-              << " concurrent clients, " << nreqs << " total requests"
-              << std::endl;
-    workers.push_back(
-        make_unique<Worker>(i, ssl_ctx, nreqs, nclients, &config));
-    auto &worker = workers.back();
-    futures.push_back(
-        std::async(std::launch::async, [&worker]() { worker->run(); }));
-  }
+    std::vector<std::future<void>> futures;
+    for (size_t i = 0; i < config.nthreads - 1; ++i) {
+      auto nreqs = nreqs_per_thread + (nreqs_rem-- > 0);
+      auto nclients = nclients_per_thread + (nclients_rem-- > 0);
+      std::cout << "spawning thread #" << i << ": " << nclients
+                << " concurrent clients, " << nreqs << " total requests"
+                << std::endl;
+      config.workers.push_back(
+          make_unique<Worker>(i, ssl_ctx, nreqs, nclients, &config));
+      auto &worker = config.workers.back();
+      futures.push_back(
+          std::async(std::launch::async, [&worker]() { worker->run(); }));
+    }
 #endif // NOTHREADS
 
-  auto nreqs_last = nreqs_per_thread + (nreqs_rem-- > 0);
-  auto nclients_last = nclients_per_thread + (nclients_rem-- > 0);
-  std::cout << "spawning thread #" << (config.nthreads - 1) << ": "
-            << nclients_last << " concurrent clients, " << nreqs_last
-            << " total requests" << std::endl;
-  workers.push_back(make_unique<Worker>(config.nthreads - 1, ssl_ctx,
-                                        nreqs_last, nclients_last, &config));
-  workers.back()->run();
+    auto nreqs_last = nreqs_per_thread + (nreqs_rem-- > 0);
+    auto nclients_last = nclients_per_thread + (nclients_rem-- > 0);
+    std::cout << "spawning thread #" << (config.nthreads - 1) << ": "
+              << nclients_last << " concurrent clients, " << nreqs_last
+              << " total requests" << std::endl;
+    config.workers.push_back(make_unique<Worker>(config.nthreads - 1, ssl_ctx,
+                                          nreqs_last, nclients_last, &config));
+    config.workers.back()->run();
 
 #ifndef NOTHREADS
-  for (auto &fut : futures) {
-    fut.get();
-  }
+    for (auto &fut : futures) {
+      fut.get();
+    }
 #endif // NOTHREADS
+  } //!config.is_rate_mode()
+  // if in rate mode, create a new worker each second
+  else {
+    // set various config values
+    config.seconds = std::min(n_time, c_time);
+
+    if ((int)config.nreqs < config.nconns) {
+      config.seconds = c_time;
+      config.workers.reserve(config.seconds);
+    }
+    else if (config.nconns == 0) {
+      config.seconds = n_time;
+    }
+    else {
+      config.workers.reserve(config.seconds);
+    }
+
+    config.conns_remainder = config.nconns % config.rate;
+
+    // config.seconds must be positive or else an exception is thrown
+    if (config.seconds <= 0) {
+      std::cerr << "Test cannot be run with current option values."
+                << " Please look at documentation for -r option for"
+                << " more information." << std::endl;
+      exit(EXIT_FAILURE);
+    }
+    config.current_worker = 0;
+
+    config.ssl_ctx = ssl_ctx;
+
+    // create timer that will go off every second
+    ev_timer timeout_watcher;
+
+    // create loop for running the timer
+    struct ev_loop *rate_loop = EV_DEFAULT;
+
+    config.rate_loop = rate_loop;
+
+    // giving the second_timeout_cb access to config
+    timeout_watcher.data = &config;
+
+    ev_init(&timeout_watcher, second_timeout_cb);
+    timeout_watcher.repeat = 1.;
+    ev_timer_again(rate_loop, &timeout_watcher);
+    ev_run(rate_loop, 0);
+  } // end rate mode section
 
   auto end = std::chrono::steady_clock::now();
   auto duration =
       std::chrono::duration_cast<std::chrono::microseconds>(end - start);
 
   Stats stats(0);
-  for (const auto &w : workers) {
+  for (const auto &w : config.workers) {
     const auto &s = w->stats;
 
     stats.req_todo += s.req_todo;
@@ -1463,7 +1599,7 @@ int main(int argc, char **argv) {
     }
   }
 
-  auto ts = process_time_stats(workers);
+  auto ts = process_time_stats(config.workers);
 
   // Requests which have not been issued due to connection errors, are
   // counted towards req_failed and req_error.
@@ -1476,7 +1612,7 @@ int main(int argc, char **argv) {
   //
   // [1] https://github.com/lighttpd/weighttp
   // [2] https://github.com/wg/wrk
-  size_t rps = 0;
+  double rps = 0;
   int64_t bps = 0;
   if (duration.count() > 0) {
     auto secd = static_cast<double>(duration.count()) / (1000 * 1000);

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -1427,18 +1427,23 @@ int main(int argc, char **argv) {
   if (config.is_rate_mode() && (int)config.max_concurrent_streams != 0 &&
       (n_time != c_time) && config.nreqs != 1 && config.nconns != 0) {
     if ((int)config.nreqs < config.nconns) {
-      std::cerr << "-C, -n: warning: two different test times are being set. "
+      std::cerr << "-C, -n: warning: number of requests conflict. "
                 << std::endl;
-      std::cerr << "The test will run for " << c_time << " seconds."
-                << std::endl;
-    } else {
-      std::cout << "-C, -n: warning: two different test times are being set. "
+      std::cerr << "The test will create "
+                << (config.max_concurrent_streams * config.nconns)
+                << " total requests." << std::endl;
+    }
+    else {
+      std::cout << "-C, -n: warning: number of requests conflict. "
                 << std::endl;
       std::cout << "The smaller of the two will be chosen and the test will "
-                << "run for " << std::min(n_time, c_time) << " seconds."
-                << std::endl;
+                << "create "
+                << std::min(config.nreqs,
+                            (size_t)(config.max_concurrent_streams * config.nconns))
+                << " total requests." << std::endl;
     }
   }
+
 
   Headers shared_nva;
   shared_nva.emplace_back(":scheme", config.scheme);

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -1432,18 +1432,17 @@ int main(int argc, char **argv) {
       std::cerr << "The test will create "
                 << (config.max_concurrent_streams * config.nconns)
                 << " total requests." << std::endl;
-    }
-    else {
+    } else {
       std::cout << "-C, -n: warning: number of requests conflict. "
                 << std::endl;
       std::cout << "The smaller of the two will be chosen and the test will "
                 << "create "
-                << std::min(config.nreqs,
-                            (size_t)(config.max_concurrent_streams * config.nconns))
+                << std::min(
+                       config.nreqs,
+                       (size_t)(config.max_concurrent_streams * config.nconns))
                 << " total requests." << std::endl;
     }
   }
-
 
   Headers shared_nva;
   shared_nva.emplace_back(":scheme", config.scheme);

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -75,8 +75,7 @@ Config::Config()
     : data_length(-1), addrs(nullptr), nreqs(1), nclients(1), nthreads(1),
       max_concurrent_streams(-1), window_bits(30), connection_window_bits(30),
       no_tls_proto(PROTO_HTTP2), data_fd(-1), port(0), default_port(0),
-      verbose(false), 
-      nconns(0), rate(0), current_worker(0) {}
+      verbose(false), nconns(0), rate(0), current_worker(0) {}
 
 Config::~Config() {
   freeaddrinfo(addrs);
@@ -86,9 +85,7 @@ Config::~Config() {
   }
 }
 
-bool Config::is_rate_mode() {    
-  return (this->rate != 0);    
-}
+bool Config::is_rate_mode() { return (this->rate != 0); }
 
 Config config;
 
@@ -975,18 +972,16 @@ void second_timeout_cb(EV_P_ ev_timer *w, int revents) {
   auto nclients_per_worker = config->rate;
   auto nreqs_per_worker = config->max_concurrent_streams * config->rate;
 
-  if(config->current_worker >= std::max(0. , (config->seconds - 1.))) {
+  if (config->current_worker >= std::max(0., (config->seconds - 1.))) {
     nclients_per_worker = config->rate + config->conns_remainder;
     nreqs_per_worker = (int)config->max_concurrent_streams *
                        (config->rate + config->conns_remainder);
     ev_timer_stop(config->rate_loop, w);
   }
 
-  config->workers.push_back(make_unique<Worker>(config->current_worker,
-                                                config->ssl_ctx,
-                                                nreqs_per_worker,
-                                                nclients_per_worker,
-                                                config));
+  config->workers.push_back(
+      make_unique<Worker>(config->current_worker, config->ssl_ctx,
+                          nreqs_per_worker, nclients_per_worker, config));
 
   config->current_worker++;
 
@@ -1068,7 +1063,8 @@ Options:
               Available protocol: )";
 #endif // !HAVE_SPDYLAY
   out << NGHTTP2_CLEARTEXT_PROTO_VERSION_ID << R"(
-              Default: )" << NGHTTP2_CLEARTEXT_PROTO_VERSION_ID << R"(
+              Default: )"
+      << NGHTTP2_CLEARTEXT_PROTO_VERSION_ID << R"(
   -d, --data=<FILE>
               Post FILE to  server.  The request method  is changed to
               POST.
@@ -1093,7 +1089,8 @@ Options:
   -v, --verbose
               Output debug information.
   --version   Display version information and exit.
-  -h, --help  Display this help and exit.)" << std::endl;
+  -h, --help  Display this help and exit.)"
+      << std::endl;
 }
 } // namespace
 
@@ -1128,8 +1125,8 @@ int main(int argc, char **argv) {
         {"num-conns", required_argument, nullptr, 'C'},
         {nullptr, 0, nullptr, 0}};
     int option_index = 0;
-    auto c = getopt_long(argc, argv, "hvW:c:d:m:n:p:t:w:H:i:r:C:", 
-                         long_options, &option_index);
+    auto c = getopt_long(argc, argv, "hvW:c:d:m:n:p:t:w:H:i:r:C:", long_options,
+                         &option_index);
     if (c == -1) {
       break;
     }
@@ -1227,8 +1224,7 @@ int main(int argc, char **argv) {
       config.rate = strtoul(optarg, nullptr, 10);
       if (config.rate <= 0) {
         std::cerr << "-r: the rate at which connections are made "
-                  << "must be positive."
-                  << std::endl;
+                  << "must be positive." << std::endl;
         exit(EXIT_FAILURE);
       }
       break;
@@ -1236,8 +1232,7 @@ int main(int argc, char **argv) {
       config.nconns = strtoul(optarg, nullptr, 10);
       if (config.nconns <= 0) {
         std::cerr << "-C: the total number of connections made "
-                  << "must be positive."
-                  << std::endl;
+                  << "must be positive." << std::endl;
         exit(EXIT_FAILURE);
       }
       break;
@@ -1311,15 +1306,13 @@ int main(int argc, char **argv) {
 
   if (config.nconns < 0) {
     std::cerr << "-C: the total number of connections made "
-              << "cannot be negative."
-              << std::endl;
+              << "cannot be negative." << std::endl;
     exit(EXIT_FAILURE);
   }
 
   if (config.rate < 0) {
     std::cerr << "-r: the rate at which connections are made "
-              << "cannot be negative."
-              << std::endl;
+              << "cannot be negative." << std::endl;
     exit(EXIT_FAILURE);
   }
 
@@ -1519,8 +1512,8 @@ int main(int argc, char **argv) {
     std::cout << "spawning thread #" << (config.nthreads - 1) << ": "
               << nclients_last << " concurrent clients, " << nreqs_last
               << " total requests" << std::endl;
-    config.workers.push_back(make_unique<Worker>(config.nthreads - 1, ssl_ctx,
-                                          nreqs_last, nclients_last, &config));
+    config.workers.push_back(make_unique<Worker>(
+        config.nthreads - 1, ssl_ctx, nreqs_last, nclients_last, &config));
     config.workers.back()->run();
 
 #ifndef NOTHREADS
@@ -1528,7 +1521,7 @@ int main(int argc, char **argv) {
       fut.get();
     }
 #endif // NOTHREADS
-  } //!config.is_rate_mode()
+  } //! config.is_rate_mode()
   // if in rate mode, create a new worker each second
   else {
     // set various config values
@@ -1537,11 +1530,9 @@ int main(int argc, char **argv) {
     if ((int)config.nreqs < config.nconns) {
       config.seconds = c_time;
       config.workers.reserve(config.seconds);
-    }
-    else if (config.nconns == 0) {
+    } else if (config.nconns == 0) {
       config.seconds = n_time;
-    }
-    else {
+    } else {
       config.workers.reserve(config.seconds);
     }
 

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -1408,7 +1408,7 @@ int main(int argc, char **argv) {
   if (config.max_concurrent_streams == -1) {
     config.max_concurrent_streams = reqlines.size();
   }
-  
+
   // if not in rate mode and -C is set, warn that we are ignoring it
   if (!config.is_rate_mode() && config.nconns != 0) {
     std::cerr << "-C: warning: This option can only be used with -r, and"
@@ -1416,10 +1416,10 @@ int main(int argc, char **argv) {
   }
 
   ssize_t n_time = 0;
-  ssize_t c_time = 0; 
+  ssize_t c_time = 0;
   // only care about n_time and c_time in rate mode
   if (config.is_rate_mode() && config.max_concurrent_streams != 0) {
-    n_time = (int)config.nreqs / 
+    n_time = (int)config.nreqs /
              ((int)config.rate * (int)config.max_concurrent_streams);
     c_time = (int)config.nconns / (int)config.rate;
   }
@@ -1429,20 +1429,17 @@ int main(int argc, char **argv) {
     if ((int)config.nreqs < config.nconns) {
       std::cerr << "-C, -n: warning: two different test times are being set. "
                 << std::endl;
-      std::cerr << "The test will run for "
-                << c_time
-                << " seconds." << std::endl;
-    }
-    else {
+      std::cerr << "The test will run for " << c_time << " seconds."
+                << std::endl;
+    } else {
       std::cout << "-C, -n: warning: two different test times are being set. "
                 << std::endl;
       std::cout << "The smaller of the two will be chosen and the test will "
-                << "run for "
-                << std::min(n_time, c_time)
-                << " seconds." << std::endl;
+                << "run for " << std::min(n_time, c_time) << " seconds."
+                << std::endl;
     }
   }
-  
+
   Headers shared_nva;
   shared_nva.emplace_back(":scheme", config.scheme);
   if (config.port != config.default_port) {
@@ -1555,7 +1552,7 @@ int main(int argc, char **argv) {
       fut.get();
     }
 #endif // NOTHREADS
-  } //! config.is_rate_mode()
+  }    //! config.is_rate_mode()
   // if in rate mode, create a new worker each second
   else {
     // set various config values

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -972,7 +972,7 @@ void second_timeout_cb(EV_P_ ev_timer *w, int revents) {
   auto nclients_per_worker = config->rate;
   auto nreqs_per_worker = config->max_concurrent_streams * config->rate;
 
-  if (config->current_worker >= std::max(0., (config->seconds - 1.))) {
+  if (config->current_worker >= std::max((ssize_t)0, (config->seconds - 1))) {
     nclients_per_worker = config->rate + config->conns_remainder;
     nreqs_per_worker = (int)config->max_concurrent_streams *
                        (config->rate + config->conns_remainder);

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -1556,16 +1556,14 @@ int main(int argc, char **argv) {
   // if in rate mode, create a new worker each second
   else {
     // set various config values
-    config.seconds = std::min(n_time, c_time);
-
     if ((int)config.nreqs < config.nconns) {
       config.seconds = c_time;
-      config.workers.reserve(config.seconds);
     } else if (config.nconns == 0) {
       config.seconds = n_time;
     } else {
-      config.workers.reserve(config.seconds);
+      config.seconds = std::min(n_time, c_time);
     }
+    config.workers.reserve(config.seconds);
 
     config.conns_remainder = config.nconns % config.rate;
 

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -74,8 +74,8 @@ namespace h2load {
 Config::Config()
     : data_length(-1), addrs(nullptr), nreqs(1), nclients(1), nthreads(1),
       max_concurrent_streams(-1), window_bits(30), connection_window_bits(30),
-      rate(0), nconns(0), no_tls_proto(PROTO_HTTP2), data_fd(-1), port(0), default_port(0),
-      verbose(false), current_worker(0) {}
+      rate(0), nconns(0), no_tls_proto(PROTO_HTTP2), data_fd(-1), port(0),
+      default_port(0), verbose(false), current_worker(0) {}
 
 Config::~Config() {
   freeaddrinfo(addrs);

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -76,6 +76,10 @@ struct Config {
   ssize_t max_concurrent_streams;
   size_t window_bits;
   size_t connection_window_bits;
+  // rate at which connections should be made
+  ssize_t rate;
+  // number of connections made
+  ssize_t nconns;
   enum { PROTO_HTTP2, PROTO_SPDY2, PROTO_SPDY3, PROTO_SPDY3_1 } no_tls_proto;
   // file descriptor for upload data
   int data_fd;
@@ -83,8 +87,17 @@ struct Config {
   uint16_t default_port;
   bool verbose;
 
+  ssize_t current_worker;
+  std::vector<std::unique_ptr<Worker>> workers;
+  SSL_CTX *ssl_ctx;
+  struct ev_loop *rate_loop;
+  ssize_t seconds;
+  ssize_t conns_remainder;
+
   Config();
   ~Config();
+
+  bool is_rate_mode();
 };
 
 struct RequestStat {

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -57,6 +57,7 @@ using namespace nghttp2;
 namespace h2load {
 
 class Session;
+struct Worker;
 
 struct Config {
   std::vector<std::vector<nghttp2_nv>> nva;


### PR DESCRIPTION
I would like to add the ability to specify a constant test time for h2load. In order to specify a constant time, I have added two new options: one to specify the rate at which connections are made, and another to specify the total number of connections to be made throughout the test. 
## Feature 1 -- connection rate

The new rate option for h2load will allow users to specify the number of connections made per second.

-r, --rate=N
Specifies the fixed rate at which connections are created. The rate must be a positive integer, representing the number of connections to be made per second. When the rate is 0, the program will run as it normally does, creating connections at whatever variable rate it wants. The default value for this option is 0. To use the -r option, the -T option and either the -C or -n option must be specified as well. 
## Feature 2 -- number of connections

The new num_conns option of h2load will allow users to specify the total number of connections created throughout the test. 

-C, --num-conns=N
Specifies the total number of connections to create. The total number of connections must be a positive integer. On each connection, -m requests are made. The test stops as soon as the N connections have either completed or failed. When the number of connections is 0, the program will run as it normally does and create as many connections as it needs in order to make the -n requests specified. The default value for this option is 0. The -n option is not required if the -C option is being used. The -C option will be ignored if the -r option is not being used.
## Usage

With these new options, there are now two ways to set a constant test time:
1. # of seconds = floor( -C / -r )
2. # of seconds = floor( -n / ( -r \* -m ) )

Either method can be used individually. If used together, the test will stop at the smaller of the two times specified. 

Examples:
Time Method 1:

```
h2load -r2 -C4 https://www.google.com
```

This test will run for (-C / -r) = (4 / 2) = 2 seconds, making 2 connections per second, with one request per connection (because only one uri was specified). 

Time Method 2:

```
h2load -r2 -n16 https://www.google.com https://www.google.com
```

This test will run for ( -n / ( -r \* -m ) ) = ( 16 / ( 2 \* 2 ) ) = 4 seconds, making 2 connections per second, each with two requests to make a total of 4 requests per second. 

Both Methods:

```
h2load -r2 -n16 -C4 https://www.google.com https://www.google.com
-C, -n: warning: two different test times are being set. 
The smaller of the two will be chosen and the test will run for 2 seconds.
starting benchmark...
Protocol: TLSv1.2
Cipher: ECDHE-RSA-AES128-GCM-SHA256

finished in 2.26s, 3.53256 req/s, 183.91KB/s
requests: 8 total, 8 started, 8 done, 8 succeeded, 0 failed, 0 errored
status codes: 8 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 426479 bytes total, 3139 bytes headers, 422648 bytes data
                     min         max         mean         sd        +/- sd
time for request:   113.72ms    150.84ms    131.61ms     16.86ms    62.50%
time for connect:   108.47ms    121.60ms    115.32ms      4.65ms    50.00%
time to 1st byte:   108.62ms    121.76ms    115.49ms      4.66ms    50.00%
```

This test has conflicting times being set, so a warning pops up, notifying the user of which time is being used. 

In this case, the -n16 option will be ignored and the test will run for ( -C / -r ) = ( 4 / 2 ) = 2 seconds, making two connections per second, each with two requests to make a total of 8 requests. 
